### PR TITLE
(j0njHLXc) // setup mui theme

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -127,7 +127,7 @@ const Header = () => {
             KZ
           </Typography>
           <SearchBar />
-          <Button variant="contained">New Post</Button>
+          <Button variant="contained" disableElevation style={{ backgroundColor: '#EBEAEC', color: '#313E50' }}>New post</Button>
           <Box sx={{ flexGrow: 1 }} />
           <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
             <IconButton size="large" aria-label="show 4 new mails" color="inherit">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,20 +1,18 @@
 import '../styles/globals.css'
-import type { AppProps } from 'next/app'
-import { Global, css } from '@emotion/react'
 
-function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <> 
-      <Global 
-        styles={css`
-          body {
-            padding: 0 !important;
-            margin: 0 !important;
-          }
-        `} 
-      />
+import type { AppProps } from 'next/app'
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+
+import { theme } from '../theme'
+
+
+const App = ({ Component, pageProps }: AppProps) => 
+  <> 
+    <MuiThemeProvider theme={theme}>
+      <CssBaseline />
       <Component {...pageProps} />
-    </>
-  )
-}
-export default MyApp
+    </MuiThemeProvider>
+  </>
+  
+export default App

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,7 +2,7 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+  font-family: Mukta, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }
 

--- a/theme.ts
+++ b/theme.ts
@@ -1,0 +1,20 @@
+import { createTheme } from '@mui/material/styles';
+
+export const theme = createTheme({
+    components: {
+        MuiButton: {
+            styleOverrides: {
+                root: {
+                    textTransform: 'inherit'
+                }
+            }
+        },
+        MuiInputBase: {
+            styleOverrides: {
+                input: {
+                    height: '20px'
+                },
+            }
+        },
+    }
+})


### PR DESCRIPTION
- setup `theme`
- wrap `App` with `ThemeProvider`
- example: height of `Input` component and text-transform of `Button` label

Screen:
<img width="574" alt="Screenshot 2021-10-17 at 13 32 44" src="https://user-images.githubusercontent.com/27337196/137625720-da5c4efb-41c0-4ff7-b901-bb4b81986897.png">

