### PR TITLE
(rbI1xeRV) // navigate to profile page

### DIFF
--- a/components/Header/HeaderLayout.tsx
+++ b/components/Header/HeaderLayout.tsx
@@ -18,5 +18,5 @@ HeaderLayout.Left = ({ children }: any) => (
   </Box>
 );
 
-HeaderLayout.Right = ({ children }: any) => <Box>{children}</Box>;
+HeaderLayout.Right = ({ children }: any) => <Box display="flex" alignItems="center" style={{ gap: '8px' }}>{children}</Box>;
 export default HeaderLayout;

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import Link from 'next/link'
 
 import Typography from '@mui/material/Typography';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -15,9 +15,11 @@ const Header = () => (
     <HeaderLayout>
         <HeaderLayout.Left>
             <IconBtn icon={<MenuIcon />} edge="start" sx={{ mr: 2 }} />
-            <Typography variant="h6" sx={{ fontFamily: 'Mukta' }}>
-              KZ
-            </Typography>
+            <Link href="/">
+              <Typography variant="h6" sx={{ fontFamily: 'Mukta', cursor: 'pointer' }}>
+                KZ
+              </Typography>
+            </Link>
             <SearchBar />
             <ButtonStyled variant="contained" disableElevation>
               New post
@@ -27,7 +29,7 @@ const Header = () => (
         <HeaderLayout.Right>
             <IconBtn icon={<TextsmsOutlinedIcon />} />
             <IconBtn icon={<NotificationsNoneIcon />} />
-            <AvatarStyled>AB</AvatarStyled>
+            <Link href="/profile"><AvatarStyled>AB</AvatarStyled></Link>
         </HeaderLayout.Right>
     </HeaderLayout>
 );

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -2,15 +2,14 @@ import * as React from 'react';
 
 import Typography from '@mui/material/Typography';
 import MenuIcon from '@mui/icons-material/Menu';
-import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone';
-import SmsIcon from '@mui/icons-material/Sms';
+import TextsmsOutlinedIcon from '@mui/icons-material/TextsmsOutlined';
 
 import HeaderLayout from './HeaderLayout';
 import IconBtn from '../IconBtn';
 import SearchBar from '../SearchBar';
 
-import { ButtonStyled } from './style';
+import { ButtonStyled, AvatarStyled} from './style';
 
 const Header = () => (
     <HeaderLayout>
@@ -26,9 +25,9 @@ const Header = () => (
         </HeaderLayout.Left>
 
         <HeaderLayout.Right>
-            <IconBtn icon={<SmsIcon />} />
+            <IconBtn icon={<TextsmsOutlinedIcon />} />
             <IconBtn icon={<NotificationsNoneIcon />} />
-            <IconBtn icon={<PersonOutlineIcon />} edge="end" />
+            <AvatarStyled>AB</AvatarStyled>
         </HeaderLayout.Right>
     </HeaderLayout>
 );

--- a/components/Header/style.ts
+++ b/components/Header/style.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { AppBar, Button } from '@mui/material';
+import { AppBar, Button, Avatar } from '@mui/material';
 
 export const AppBarStyled = styled(AppBar)`
   background-color: white;
@@ -20,3 +20,14 @@ export const ButtonStyled = styled(Button)`
       0 -1px 0 rgba(0, 0, 0, 0.05), -1px 0 0 rgba(0, 0, 0, 0.05), 1px 0 0 rgba(0, 0, 0, 0.05);
   }
 `;
+
+export const AvatarStyled = styled(Avatar)`
+  width: 35px;
+  height: 35px;
+  font-size: 0.75rem;
+  font-weight: bold;
+  background-color: #D9C5B2;
+  color: black;
+  border: 1px solid black;
+  cursor: pointer;
+`

--- a/components/ToggleButtons/index.tsx
+++ b/components/ToggleButtons/index.tsx
@@ -21,7 +21,7 @@ const ColorToggleButton = () => {
       value={alignment}
       exclusive
       onChange={handleChange}
-      sx={{ gap: '8px', mb: 4 }}
+      sx={{ gap: '16px', mb: 4, justifyContent: 'center' }}
     >
       <StyledToggleButton value="popular" size="small" active={alignment === 'popular'}>
         <WhatshotIcon />

--- a/components/ToggleButtons/index.tsx
+++ b/components/ToggleButtons/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import WhatshotIcon from '@mui/icons-material/Whatshot';
@@ -9,7 +9,7 @@ import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import { StyledToggleButton } from './style';
 
 const ColorToggleButton = () => {
-  const [alignment, setAlignment] = React.useState('popular');
+  const [alignment, setAlignment] = useState('popular');
 
   const handleChange = (event: React.MouseEvent<HTMLElement>, newAlignment: string) => {
     setAlignment(newAlignment);

--- a/components/ToggleButtons/style.ts
+++ b/components/ToggleButtons/style.ts
@@ -2,9 +2,6 @@ import styled from '@emotion/styled';
 import ToggleButton from '@mui/material/ToggleButton';
 
 export const StyledToggleButton = styled(ToggleButton)<{ active: boolean }>`
-  justify-content: center;
-  gap: 1rem;
-  
   &::after {
     content: '';
     display: block;

--- a/components/ToggleButtons/style.ts
+++ b/components/ToggleButtons/style.ts
@@ -2,6 +2,9 @@ import styled from '@emotion/styled';
 import ToggleButton from '@mui/material/ToggleButton';
 
 export const StyledToggleButton = styled(ToggleButton)<{ active: boolean }>`
+  justify-content: center;
+  gap: 1rem;
+  
   &::after {
     content: '';
     display: block;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Paper from '@mui/material/Paper';
 
 import ColorToggleButton from '../components/ToggleButtons';
 import Post from '../components/Post';

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -1,0 +1,21 @@
+import Head from 'next/head'
+
+import MainLayout from '../../layout'
+
+const ProfilePage = () => {
+  return (
+    <div>
+      <Head>
+        <title>My page title</title>
+        <meta property="og:title" content="My page title" key="title" />
+      </Head>
+      <Head>
+        <meta property="og:title" content="My new title" key="title" />
+      </Head>
+      <h3>Profile Page</h3>
+    </div>
+  )
+}
+
+ProfilePage.PageLayout = MainLayout
+export default ProfilePage


### PR DESCRIPTION
- change `Person` icon to `Avatar` component
- center `ToggleButtons` group
- navigate to `Profile Page` when avatar gets clicked
- naviagete back to `Home Page` when logo gets clicked

https://user-images.githubusercontent.com/27337196/139637883-30381607-952e-4caf-85f6-0272e6d60ffb.mov



